### PR TITLE
publish for tags, compress cpio images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: u-root-builder
+name: u-root-buildcheck
 
 on:
   push:
@@ -7,7 +7,6 @@ on:
     branches: [ "main" ]
 
 jobs:
-
   build:
     strategy:
       matrix:
@@ -23,14 +22,11 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.20'
+        go-version: '1.21'
 
     - name: Build
       run: |
         go build .
-        GOARCH=${{ matrix.arch }} ./u-root -uroot-source . -o u-root-${{ matrix.arch }}-${{ matrix.template }}.cpio ${{ matrix.template }}
-
-    - name: Upload
-      uses: actions/upload-artifact@v3.1.3
-      with:
-        path: u-root-${{ matrix.arch }}-${{ matrix.template }}.cpio
+        GOARCH=${{ matrix.arch }} ./u-root -uroot-source . \
+          -o u-root-${{ matrix.arch }}-${{ matrix.template }}.cpio \
+          ${{ matrix.template }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,44 @@
+name: u-root-publish
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  publish:
+    strategy:
+      matrix:
+        template: [core, all, embedded, minimal]
+        arch: [amd64, arm, arm64, riscv64]
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        repository: u-root/u-root
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.21'
+
+    - name: Build
+      run: |
+        go build .
+        GOARCH=${{ matrix.arch }} ./u-root -uroot-source . \
+          -o ${{ matrix.arch }}-${{ matrix.template }}.cpio \
+          ${{ matrix.template }}
+        xz --check=crc32 -9 --lzma2=dict=1MiB \
+          --stdout ${{ matrix.arch }}-${{ matrix.template }}.cpio | \
+          dd conv=sync bs=512 \
+          of=${{ matrix.arch }}-${{ matrix.template }}.cpio.xz
+
+    - name: Upload
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        tag: ${{ github.ref }}
+        file: ${{ matrix.arch }}-${{ matrix.template }}.cpio.xz
+        asset_name: u-root_${{ matrix.arch }}_${{ matrix.template }}.cpio.xz


### PR DESCRIPTION
This only builds for PRs and drops the artifact upload, and publishes attachements for tags instead, so that each individual file can be downloaded from a release page on GitHub.

We should figure out if we can share the u-root commit to use between the two actions, or find some other solution.